### PR TITLE
Fix ses client to properly take in specified region

### DIFF
--- a/aws_cfn_ses_domain/__about__.py
+++ b/aws_cfn_ses_domain/__about__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = (0, 2)
+VERSION = (0, 3)
 __version__ = ".".join(str(v) for v in VERSION)
 
 NAME = "aws-cfn-ses-domain"


### PR DESCRIPTION
This fixes what seems to be a bug where the SES boto3 client is not being initialized with the proper region, making it so that if you are attempting to create a stack in a region that does not support SES the requests to API calls will fail.