### PR TITLE
Add the ability to optionally verify an email address

### DIFF
--- a/aws_cfn_ses_domain/__about__.py
+++ b/aws_cfn_ses_domain/__about__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = (0, 2)
+VERSION = (0, 3)
 __version__ = ".".join(str(v) for v in VERSION)
 
 NAME = "aws-cfn-ses-domain"

--- a/aws_cfn_ses_domain/__about__.py
+++ b/aws_cfn_ses_domain/__about__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = (0, 3)
+VERSION = (0, 4)
 __version__ = ".".join(str(v) for v in VERSION)
 
 NAME = "aws-cfn-ses-domain"

--- a/aws_cfn_ses_domain/lambda_function.py
+++ b/aws_cfn_ses_domain/lambda_function.py
@@ -25,8 +25,6 @@ DEFAULT_PROPERTIES = {
 }
 
 
-ses = boto3.client('ses')
-
 
 def lambda_handler(event, context):
     logger.info("Received event %r", event)
@@ -75,6 +73,8 @@ def lambda_handler(event, context):
 
 
 def update_ses_domain_identity(domain, properties):
+    ses = boto3.client('ses', region_name=properties['Region'])
+
     """Handle SES (de-)provisioning for domain and returns dict of output info"""
     outputs = {}
     enable_send = properties["EnableSend"]

--- a/aws_cfn_ses_domain/lambda_function.py
+++ b/aws_cfn_ses_domain/lambda_function.py
@@ -60,7 +60,7 @@ def lambda_handler(event, context):
         return send(event, context, FAILED,
                     reason=str(error), physical_resource_id=domain)
 
-    if email:
+    if email and event["RequestType"] != "Delete":
         try:
             update_ses_email_identity(email, properties)
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,10 +1,11 @@
 import os
+import boto3
 from unittest import TestCase
 from unittest.mock import patch, ANY as MOCK_ANY
 from botocore.stub import Stubber
 
 os.environ["AWS_REGION"] = "mock-region"  # (before loading lambda_function)
-from aws_cfn_ses_domain.lambda_function import lambda_handler, ses
+from aws_cfn_ses_domain.lambda_function import lambda_handler
 
 
 mock_context = object()
@@ -16,6 +17,10 @@ class TestLambdaHandler(TestCase):
     maxDiff = None
 
     def setUp(self):
+        ses = boto3.client('ses')  # need a real client for Stubber
+        boto3_client_patcher = patch('aws_cfn_ses_domain.lambda_function.boto3.client', return_value=ses)
+        self.mock_boto3_client = boto3_client_patcher.start()
+        self.addCleanup(boto3_client_patcher.stop)
         self.ses_stubber = Stubber(ses)
         self.ses_stubber.activate()
         self.addCleanup(self.ses_stubber.deactivate)


### PR DESCRIPTION
When creating a new SES domain, if the user has not yet gotten out of the sandbox, they will only be able to send emails to verified email address. This PR adds the ability for an optional `EmailAddress` parameter to verify during the stack deploy.