### PR TITLE
Add `Custom::SES_EmailIdentity` resource type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,20 @@
 
 ### Features
 
+* Add a new [`Custom::SES_EmailIdentity`](README.md#customses_emailidentity) custom
+  resource type for managing Amazon SES verified email addresses.
+
 * Make [`Arn`](README.md#other-attributes) and [`Region`](README.md#other-attributes)
   attributes available on `Custom::SES_Domain` resources.
+
+### Deprecations
+
+* The `ServiceToken` used for a `Custom::SES_Domain` has changed from the nested stack's
+  `...Outputs.Arn` to `...Outputs.CustomDomainIdentityArn` (to distinguish it from the 
+  new `...Outputs.CustomEmailIdentityArn` for `Custom::SES_EmailIdentity` resources).
+  If your templates use something like `ServiceToken: !GetAtt CfnSESDomain.Outputs.Arn`, 
+  they will continue to work with v0.3, but you should replace `Arn` to prepare for
+  future releases: `ServiceToken: !GetAtt CfnSESDomain.Outputs.CustomDomainIdentityArn`.
 
 
 ## v0.2

--- a/CustomSESDomainSpecification.json
+++ b/CustomSESDomainSpecification.json
@@ -93,6 +93,40 @@
           "PrimitiveType": "String"
         }
       }
+    },
+    "Custom::SES_EmailIdentity": {
+      "Documentation": "https://github.com/medmunds/aws-cfn-ses-domain/blob/master/README.md",
+      "Properties": {
+        "ServiceToken": {
+          "Documentation": "https://github.com/medmunds/aws-cfn-ses-domain/blob/master/README.md#servicetoken-2",
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        },
+        "EmailAddress": {
+          "Documentation": "https://github.com/medmunds/aws-cfn-ses-domain/blob/master/README.md#emailaddress",
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        },
+        "Region": {
+          "Documentation": "https://github.com/medmunds/aws-cfn-ses-domain/blob/master/README.md#region-2",
+          "PrimitiveType": "String",
+          "Required": false,
+          "UpdateType": "Immutable"
+        }
+      },
+      "Attributes": {
+        "EmailAddress": {
+          "PrimitiveType": "String"
+        },
+        "Region": {
+          "PrimitiveType": "String"
+        },
+        "Arn": {
+          "PrimitiveType": "String"
+        }
+      }
     }
   },
   "ResourceSpecificationVersion": "2.11.0"

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ upload: | all
 	  's3://$(S3_BUCKET)$(if $(S3_PREFIX),/$(S3_PREFIX),)/'
 
 
-.PHONY: deploy
+.PHONY: deploy-example
 ## Deploy the example CloudFormation stack for DOMAIN or EMAIL
 deploy-example: $(ARTIFACTS_DIR)/example-usage-$(VERSION).cf.yaml
 ifeq ($(or $(DOMAIN),$(EMAIL)),)

--- a/Makefile
+++ b/Makefile
@@ -144,18 +144,16 @@ upload: | all
 
 
 .PHONY: deploy
-## Deploy the example CloudFormation stack for DOMAIN
-deploy: $(ARTIFACTS_DIR)/example-usage-$(VERSION).cf.yaml
-ifndef DOMAIN
-	$(error Set DOMAIN to make this target (`make DOMAIN=example.com $@`))
+## Deploy the example CloudFormation stack for DOMAIN or EMAIL
+deploy-example: $(ARTIFACTS_DIR)/example-usage-$(VERSION).cf.yaml
+ifeq ($(or $(DOMAIN),$(EMAIL)),)
+	$(error Set DOMAIN and/or EMAIL to make this target (`make DOMAIN=example.com $@`))
 else
 	$(AWS) cloudformation deploy \
 	  --template-file '$(ARTIFACTS_DIR)/example-usage-$(VERSION).cf.yaml' \
-	  --stack-name example-ses-domain \
+	  --stack-name example-ses-resources \
 	  --capabilities CAPABILITY_IAM \
-	  --parameter-overrides \
-	    Domain='$(DOMAIN)' \
-	    CfnSESDomainTemplateURL='https://s3.amazonaws.com/$(S3_BUCKET)/$(S3_LAMBDA_ZIP_KEY)'
+	  --parameter-overrides Domain='$(DOMAIN)' EmailAddress='$(EMAIL)'
 endif
 
 
@@ -226,7 +224,7 @@ check: $(cf_sources)
 # Help
 # Adapted from https://gist.github.com/prwhite/8168133#gistcomment-2278355
 #
-TARGET_COL_WIDTH := 10
+TARGET_COL_WIDTH := 15
 
 .PHONY: help
 ## Show this usage info
@@ -236,7 +234,7 @@ help:
 	@echo '  $(BOLD)make$(RESET) [ VARIABLE=value ... ] target ...'
 	@echo ''
 	@echo '$(BOLD)TARGETS$(RESET)'
-	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+	@awk '/^[a-zA-Z0-9_-]+:/ { \
 		description = match(lastLine, /^## (.*)/); \
 		if (description) { \
 			target = $$1; sub(/:$$/, "", target); \

--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
-# AWS CloudFormation SES Domain Custom Resource
+# Amazon CloudFormation missing resources for Amazon SES
 
-AWS [CloudFormation][] provides several built-in Amazon SES resource types,
-but oddly omits any way to manage SES domain identities. This package implements
-a `Custom::SES_Domain` CloudFormation [custom resource][custom-resource] that
-offers that missing functionality. 
+AWS [CloudFormation][] provides several built-in 
+[Amazon SES resource types][cfn-ses-resources], but is oddly missing the ones 
+most needed to get going with SES: **domain and email verification**. 
 
-You can use it to provision a domain for sending and/or receiving email through SES.
-The `Custom::SES_Domain` resource handles all required Amazon SES identity management 
-calls and outputs SES's required DNS entries. 
+This package implements those missing types as CloudFormation 
+[custom resources][custom-resource]: `Custom::SES_Domain` and
+`Custom::SES_EmailIdentity`. 
 
-The `Custom::SES_Domain` resource deliberately avoids manipulating Route 53 itself. 
-Instead, it returns an attribute that helps your template use a standard
-[`AWS::Route53::RecordSetGroup`][RecordSetGroup] resource for those DNS entries. 
-Or if you prefer, you can use other `Custom::SES_Domain` return values to customize 
-DNS records for Route 53, or to use some other DNS provider entirely.
+You can use `Custom::SES_Domain` to verify domains for sending and/or receiving 
+email through Amazon SES. It handles the SES domain verification calls and outputs 
+SES's required DNS entries, so you can feed them directly into a standard
+`AWS::Route53::RecordSetGroup` resource (or to another DNS provider if you're not 
+using Route 53).
 
-As an added benefit, this approach lets CloudFormation determine the optimal DNS 
-updating strategy if you change your stack (e.g., to add inbound capability to an 
-SES domain originally provisioned for sending only).
+Similarly, you can use `Custom::SES_EmailIdentity` to verify individual email addresses
+for sending through Amazon SES.
+
+The custom resource implementations will properly create, update, and delete Amazon SES
+identities as you modify your CloudFormation stack.
+
 
 **Documentation**
 
 * [Installation](#installation)
 * [Usage](#usage)
-  * [Properties](#properties)
-  * [Return Values](#return-values)
+  * [Custom::SES_Domain](#customses_domain)
+    * [Properties](#properties)
+    * [Return Values](#return-values)
+  * [Custom::SES_EmailIdentity](#customses_emailidentity)
+    * [Properties](#properties-1)
+    * [Return Values](#return-values-1)
   * [Validating Your Templates](#validating-your-templates)
 * [Development](#development)
 * [Alternatives](#alternatives)
@@ -33,9 +39,9 @@ SES domain originally provisioned for sending only).
 
 ## Installation
 
-The `Custom::SES_Domain` resource is implemented as an AWS Lambda Function. To use it
-from your CloudFormation templates, you'll need to set up that function along with an 
-IAM role giving it permission to manage your Amazon SES domains.
+The custom SES resources are implemented as AWS Lambda Functions. To use them
+from your CloudFormation templates, you'll need to set up the functions along with 
+IAM roles giving them permission to manage your Amazon SES domain/email identities.
 
 The easiest way to do this is with a CloudFormation [nested stack][NestedStack]: 
 
@@ -46,10 +52,10 @@ The easiest way to do this is with a CloudFormation [nested stack][NestedStack]:
    need not be public. 
    
 2. Then in your CloudFormation template, use a nested stack to create the Lambda 
-   Function and IAM role for the `Custom::SES_Domain` type:
+   Functions and IAM roles for the custom SES resource types:
 
 ```yaml
-  CfnSESDomain:
+  CfnSESResources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: https://s3.amazonaws.com/YOUR_BUCKET/aws-cfn-ses-domain-VERSION.cf.yaml
@@ -58,25 +64,34 @@ The easiest way to do this is with a CloudFormation [nested stack][NestedStack]:
         LambdaCodeS3Key: aws-cfn-ses-domain-VERSION.lambda.zip
 ```
 
-The `Custom::SES_Domain` resource type is now available to use like this (see 
-[Usage](#usage) below for the full list of properties and return values):
+The `Custom::SES_Domain` and `Custom::SES_EmailIdentity` resource types are now 
+available to use like this (see [Usage](#usage) below for the full list of properties 
+and return values):
 
 ```yaml
   MySESDomain:
     Type: Custom::SES_Domain
     Properties:
-      # ServiceToken must be the Arn of the Lambda Function:
-      ServiceToken: !GetAtt CfnSESDomain.Outputs.Arn
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomDomainIdentityArn
       Domain: "example.com"
+      # ...
+
+  MySESEmailIdentity:
+    Type: Custom::SES_EmailIdentity
+    Properties:
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomEmailIdentityArn
+      EmailAddress: "sender@example.com"
       # ...
 ```
 
-If you'd prefer to build and upload the `Custom::SES_Domain` code from source, 
+If you'd prefer to build and upload the custom resource code from source, 
 see the [Development](#development) section.
 
 
 
 ## Usage
+
+### `Custom::SES_Domain`
 
 To work with a `Custom::SES_Domain` resource in your CloudFormation template, you'll
 typically:
@@ -98,7 +113,7 @@ Here's how that looks in a cloudformation.yaml template…
 ```yaml
 Resources:
   # 1. Define the Custom::SES_Domain's Lambda Function via a nested stack. 
-  CfnSESDomain:
+  CfnSESResources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: https://s3.amazonaws.com/YOUR_BUCKET/aws-cfn-ses-domain-VERSION.cf.yaml
@@ -110,8 +125,8 @@ Resources:
   MySESDomain:
     Type: Custom::SES_Domain
     Properties:
-      # ServiceToken is the Arn of the Lambda Function defined above:
-      ServiceToken: !GetAtt CfnSESDomain.Outputs.Arn
+      # ServiceToken is the Arn of a Lambda Function from the nested stack:
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomDomainIdentityArn
       # Remaining Properties are options for provisioning for your SES domain identity:
       # (Domain is required; all others are optional and shown with their defaults)
       Domain: "example.com"
@@ -134,7 +149,7 @@ Resources:
       RecordSets: !GetAtt MySESDomain.Route53RecordSets
 ```
 
-### Properties
+#### Properties
 
 A `Custom::SES_Domain` resource supports the following Properties:
 
@@ -144,6 +159,9 @@ The ARN of the Lambda Function that implements the `Custom::SES_Domain` type.
 See [Installation](#installation) above for a simple way to obtain this.
 (This is a standard property of all CloudFormation 
 [AWS::CloudFormation::CustomResource][CustomResource] types.)
+
+Note that `Custom::SES_Domain` and `Custom::SES_EmailIdentity` use *different*
+ServiceToken ARNs, even though both are provided from the same nested stack. 
 
 *Required:* Yes
 
@@ -278,9 +296,9 @@ lambda function is running.)
 
 
 
-### Return Values
+#### Return Values
 
-#### Ref
+##### Ref
 
 When a `Custom::SES_Domain` resource is provided to the `Ref` intrinsic function, 
 `Ref` returns the Amazon Resource Name (ARN) of the Amazon SES domain identity 
@@ -290,14 +308,14 @@ When a `Custom::SES_Domain` resource is provided to the `Ref` intrinsic function
 as `!GetAtt MySESDomain.Domain`).
 
 
-#### Fn::GetAtt
+##### Fn::GetAtt
 
 A `Custom::SES_Domain` resource returns several [`Fn::GetAtt`][GetAtt] attributes that 
 can be used with other CloudFormation resources to maintain the required DNS records 
 for your Amazon SES domain.
 
 
-##### `Route53RecordSets`
+###### `Route53RecordSets`
 
 A List of [`AWS::Route53::RecordSet`][RecordSet] objects specifying the DNS records
 required for the `Custom::SES_Domain` identity.
@@ -318,7 +336,7 @@ will change accordingly, and CloudFormation will figure out the precise updates
 needed to the Route 53 records.
 
 
-##### `ZoneFileEntries`
+###### `ZoneFileEntries`
 
 A List of String lines that can be used in a standard [Zone File][ZoneFile] to specify 
 the DNS records required for the `Custom::SES_Domain` identity. The *name* field in each
@@ -349,7 +367,7 @@ Outputs:
 ```
 
 
-##### Other attributes
+###### Other attributes
 
 A `Custom::SES_Domain` resource provides several other SES-related attributes which
 may be helpful for generating custom DNS records or other purposes:
@@ -385,19 +403,137 @@ may be helpful for generating custom DNS records or other purposes:
   was provisioned 
 
 
+### `Custom::SES_EmailIdentity`
+
+To work with a `Custom::SES_EmailIdentity` resource in your CloudFormation template, 
+you'll typically:
+
+1. Define the AWS Lambda Function that implements the `Custom::SES_EmailIdentity` 
+  CloudFormation custom resource type, as shown in [Installation](#installation) above.
+
+2. Declare one or more `Custom::SES_EmailIdentity` resource for your the email addresses
+   you need to verify. 
+
+Here's how that looks in a cloudformation.yaml template…
+
+```yaml
+Resources:
+  # 1. Define the Custom::SES_EmailIdentity's Lambda Function via a nested stack. 
+  CfnSESResources:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/YOUR_BUCKET/aws-cfn-ses-domain-VERSION.cf.yaml
+      Parameters:
+        LambdaCodeS3Bucket: YOUR_BUCKET
+        LambdaCodeS3Key: aws-cfn-ses-domain-VERSION.lambda.zip
+
+  # 2. Declare Custom::SES_EmailIdentity resources for each address to verify.
+  MySESSender:
+    Type: Custom::SES_EmailIdentity
+    Properties:
+      # ServiceToken is the Arn of a Lambda Function from the nested stack:
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomEmailIdentityArn
+      # Remaining Properties are options for verifying the email address:
+      # (EmailAddress is required; all others are optional and shown with their defaults)
+      EmailAddress: "sender@example.com"
+      Region: !Ref "AWS::Region"
+
+  MySESReplyTo:
+    Type: Custom::SES_EmailIdentity
+    Properties:
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomEmailIdentityArn
+      EmailAddress: "noreply@example.com"
+```
+
+#### Properties
+
+##### `ServiceToken`
+
+The ARN of the Lambda Function that implements the `Custom::SES_EmailIdentity` type.
+See [Installation](#installation) above for a simple way to obtain this.
+(This is a standard property of all CloudFormation 
+[AWS::CloudFormation::CustomResource][CustomResource] types.)
+
+Note that `Custom::SES_Domain` and `Custom::SES_EmailIdentity` use *different*
+ServiceToken ARNs, even though both are provided from the same nested stack. 
+
+*Required:* Yes
+
+*Type:* String
+
+*Update requires:* Updates are not supported
+
+
+##### `EmailAddress` 
+
+The email address you want to verify for sending through Amazon SES, such as 
+`sender@example.com`. This cannot include any "display name", and must be a single
+email address. (If you need to verify multiple addresses, simply create as many
+`Custom::SES_EmailAddress` resources as needed.)
+
+AWS will send a verification email to this address the first time the stack containing
+the `Custom::SES_EmailAddress` resource is deployed, and again on any stack updates
+that alter the resource (such as changing its `Region`). 
+
+For more information, see [Verifying Email Addresses in Amazon SES][verifying-ses-emails] 
+in the *Amazon SES Developer Guide.*
+
+*Required:* Yes
+
+*Type:* String
+
+*Update requires:* Replacement
+
+
+##### `Region`
+
+The AWS Region where the email address will be verified, e.g., `"us-east-1"`. 
+This must be a region where Amazon SES is supported. The default is the region where
+your CloudFormation stack is running (or technically, where the 
+`Custom::SES_EmailIdentity` lambda function is running.)
+
+*Required:* No
+
+*Type:* String
+
+*Default:* `${AWS::Region}`
+
+*Update requires:* Replacement
+
+
+#### Return Values
+
+##### Ref
+
+When a `Custom::SES_EmailIdentity` resource is provided to the `Ref` intrinsic function, 
+`Ref` returns the Amazon Resource Name (ARN) of the Amazon SES email identity 
+(e.g., `arn:aws:ses:us-east-1:111111111111:identity/sender@example.com`).
+
+##### Fn::GetAtt
+
+A `Custom::SES_EmailIdentity` resource returns a few [`Fn::GetAtt`][GetAtt] attributes
+that may be helpful for working with it elsewhere in your template.
+
+* `Arn` (String): the Amazon Resource Name (ARN) of the Amazon SES email identity 
+  (this is the same value returned by [`!Ref MySESEmailAddress`](#ref-1))
+* `EmailAddress` (String): the [`EmailAddress`](#emailaddress) that was verified
+* `Region` (String): the resolved [`Region`](#region-1) where the email identity 
+  was verified 
+
+
 ### Validating Your Templates
 
 If you use [cfn-lint][] (recommended!) to check your CloudFormation templates,
-you can include an "override spec" so your `Custom::SES_Domain` properties and 
-attributes will be validated. Download a copy of 
-[CustomSESDomainSpecification.json](CustomSESDomainSpecification.json) and then:
+you can include an "override spec" so your `Custom::SES_Domain` and 
+`Custom::SES_EmailIdentity` properties and attributes will be validated. Download a 
+copy of [CustomSESDomainSpecification.json](CustomSESDomainSpecification.json) and then:
 
 ```bash
 cfn-lint --override-spec CustomSESDomainSpecification.json YOUR-TEMPLATE.cf.yaml
 ``` 
 
 (Without the override-spec, cfn-lint will allow *any* properties and values for
-`Custom::SES_Domain` resources.)
+`Custom::SES_Domain` and `Custom::SES_EmailIdentity` resources.)
 
 
 ## Development
@@ -450,13 +586,15 @@ domain identity features:
 
 Adding them is likely straightforward; contributions are welcome.
 
-Are you from Amazon? It'd be great to have an `AWS::SES::Domain` resource
+Are you from Amazon? It'd be great to have these resources
 standard in CloudFormation. Please consider adopting or obsoleting this package. 
 (Just reach out if you'd like me to assign or transfer it.)
 
 
 [cfn-lint]:
   https://github.com/awslabs/cfn-python-lint
+[cfn-ses-resources]:
+  https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_SES.html
 [CloudFormation]:
   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html
 [custom-mail-from-domain]: 
@@ -487,5 +625,7 @@ standard in CloudFormation. Please consider adopting or obsoleting this package.
   https://docs.aws.amazon.com/ses/latest/APIReference/API_VerifyDomainIdentity.html
 [verifying-ses-domains]: 
   https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html
+[verifying-ses-emails]: 
+  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html
 [ZoneFile]: 
   https://en.wikipedia.org/wiki/Zone_file

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amazon CloudFormation missing resources for Amazon SES
+# AWS CloudFormation resources for Amazon SES domain and email identities
 
 AWS [CloudFormation][] provides several built-in 
 [Amazon SES resource types][cfn-ses-resources], but is oddly missing the ones 
@@ -156,9 +156,11 @@ A `Custom::SES_Domain` resource supports the following Properties:
 ##### `ServiceToken`
 
 The ARN of the Lambda Function that implements the `Custom::SES_Domain` type.
-See [Installation](#installation) above for a simple way to obtain this.
 (This is a standard property of all CloudFormation 
 [AWS::CloudFormation::CustomResource][CustomResource] types.)
+
+If you are using a nested stack as recommended in [Installation](#installation) above,
+the `ServiceToken` should be set to the nested stack's `Outputs.CustomDomainIdentityArn`.
 
 Note that `Custom::SES_Domain` and `Custom::SES_EmailIdentity` use *different*
 ServiceToken ARNs, even though both are provided from the same nested stack. 
@@ -450,11 +452,13 @@ Resources:
 ##### `ServiceToken`
 
 The ARN of the Lambda Function that implements the `Custom::SES_EmailIdentity` type.
-See [Installation](#installation) above for a simple way to obtain this.
 (This is a standard property of all CloudFormation 
 [AWS::CloudFormation::CustomResource][CustomResource] types.)
 
-Note that `Custom::SES_Domain` and `Custom::SES_EmailIdentity` use *different*
+If you are using a nested stack as recommended in [Installation](#installation) above,
+the `ServiceToken` should be set to the nested stack's `Outputs.CustomEmailIdentityArn`.
+
+Note that `Custom::SES_EmailIdentity` and `Custom::SES_Domain` use *different*
 ServiceToken ARNs, even though both are provided from the same nested stack. 
 
 *Required:* Yes
@@ -584,9 +588,15 @@ domain identity features:
 * Control over Easy DKIM enabling (SES:SetIdentityDkimEnabled—currently, 
   `Custom::SES_Domain` assumes if you are enabling sending, you also want Easy DKIM)
 
+And the `Custom::SES_EmailIdentity` implementation is currently missing this Amazon SES
+email identity feature:
+
+* Ability to use a custom verification email template (SES:SendCustomVerificationEmail)
+  and configuration set when verifying an email address.
+
 Adding them is likely straightforward; contributions are welcome.
 
-Are you from Amazon? It'd be great to have these resources
+Are you from Amazon? It'd be great to have the SES domain and email identity resources
 standard in CloudFormation. Please consider adopting or obsoleting this package. 
 (Just reach out if you'd like me to assign or transfer it.)
 

--- a/aws-cfn-ses-domain.cf.yaml
+++ b/aws-cfn-ses-domain.cf.yaml
@@ -2,8 +2,8 @@ AWSTemplateFormatVersion: "2010-09-09"
 
 Description: >
   Creates an AWS Lambda Function that can be used as a CloudFormation CustomResource
-  to provision and verify an Amazon SES domain identity for sending and/or receiving
-  email. (See the readme for more information.)
+  to manage Amazon SES resources that aren't built into CloudFormation, including
+  domain identities and email identities. (See the readme for more information.)
 
 Parameters:
   LambdaCodeS3Bucket:
@@ -20,15 +20,25 @@ Parameters:
       The S3 key to the LAMBDA_ZIP deployment package.
 
 Outputs:
+  CustomDomainIdentityArn:
+    Description: The ServiceToken for the Custom::SES_DomainIdentity resource
+    Value: !GetAtt CustomDomainLambdaFunction.Arn
+  CustomEmailIdentityArn:
+    Description: The ServiceToken for the Custom::SES_EmailIdentity resource
+    Value: !GetAtt CustomEmailLambdaFunction.Arn
   Arn:
-    Description: The ServiceToken for the Custom::SES_Domain resource
-    Value: !GetAtt LambdaFunction.Arn
+    Description: >
+      (DEPRECATED - Use CustomDomainIdentityArn instead)
+      The ServiceToken for the Custom::SES_Domain resource
+    Value: !GetAtt CustomDomainLambdaFunction.Arn
   Name:
-    Description: The AWS::Lambda::Function that implements Custom::SES_Domain
-    Value: !Ref LambdaFunction
+    Description: >
+      (DEPRECATED - shouldn't be necessary)
+      The AWS::Lambda::Function that implements Custom::SES_Domain
+    Value: !Ref CustomDomainLambdaFunction
 
 Resources:
-  LambdaExecutionRole:
+  CustomDomainLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -60,12 +70,49 @@ Resources:
             - ses:VerifyDomainIdentity
             Resource: "*"
 
-  LambdaFunction:
+  CustomEmailLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: AssumeLambdaExecutionRole
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      # (allows logging)
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: ProvisionSESEmailIdentities
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Sid: AllowSESEmailIdentityProvisioning
+            Effect: Allow
+            Action:
+            - ses:DeleteIdentity
+            - ses:VerifyEmailIdentity
+            Resource: "*"
+
+  CustomDomainLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
       Description: CloudFormation custom SES domain provisioning
-      Handler: index.lambda_handler
-      Role: !GetAtt LambdaExecutionRole.Arn
+      Handler: index.handle_domain_identity_request
+      Role: !GetAtt CustomDomainLambdaExecutionRole.Arn
+      Runtime: python3.6
+      Code:
+        S3Bucket: !Ref LambdaCodeS3Bucket
+        S3Key: !Ref LambdaCodeS3Key
+
+  CustomEmailLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: CloudFormation custom SES email identity provisioning
+      Handler: index.handle_email_identity_request
+      Role: !GetAtt CustomEmailLambdaExecutionRole.Arn
       Runtime: python3.6
       Code:
         S3Bucket: !Ref LambdaCodeS3Bucket

--- a/aws_cfn_ses_domain/__init__.py
+++ b/aws_cfn_ses_domain/__init__.py
@@ -1,2 +1,3 @@
-from .lambda_function import lambda_handler
 from .__about__ import __version__, VERSION
+from .ses_domain_identity import handle_domain_identity_request
+from .ses_email_identity import handle_email_identity_request

--- a/aws_cfn_ses_domain/ses_domain_identity.py
+++ b/aws_cfn_ses_domain/ses_domain_identity.py
@@ -8,6 +8,7 @@ import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
 from .cfnresponse import FAILED, SUCCESS, send
+from .utils import format_arn
 
 
 logger = logging.getLogger()
@@ -25,7 +26,7 @@ DEFAULT_PROPERTIES = {
 }
 
 
-def lambda_handler(event, context):
+def handle_domain_identity_request(event, context):
     logger.info("Received event %r", event)
 
     properties = DEFAULT_PROPERTIES.copy()
@@ -91,9 +92,9 @@ def lambda_handler(event, context):
 
 
 def update_ses_domain_identity(domain, properties):
+    """Handle SES (de-)provisioning for domain and returns dict of output info"""
     ses = boto3.client('ses', region_name=properties['Region'])
 
-    """Handle SES (de-)provisioning for domain and returns dict of output info"""
     outputs = {}
     enable_send = properties["EnableSend"]
     enable_receive = properties["EnableReceive"]
@@ -195,32 +196,3 @@ def route53_to_zone_file(records):
             ttl=record["TTL"], type=record["Type"],
             data=" ".join(record["ResourceRecords"]))
         for record in records]
-
-
-def format_arn(partition=None, service=None, region=None, account=None,
-               resource=None, resource_type=None, resource_name=None,
-               defaults_from=None):
-    """Return an ARN composed from the specified components.
-
-    Provide either resource or both resource_type and resource_name.
-
-    defaults_from can be an existing ARN, which will be used to fill in any
-    missing components.
-
-    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
-    for the format.
-    """
-    if resource is None and resource_type is not None:
-        resource = f"{resource_type}/{resource_name}"
-    if defaults_from is not None:
-        try:
-            _arn, _partition, _service, _region, _account, _resource = defaults_from.split(":")
-        except (TypeError, ValueError):
-            raise ValueError(f"Invalid ARN in defaults_from={defaults_from!r}")
-        partition = partition if partition is not None else _partition
-        service = service if service is not None else _service
-        region = region if region is not None else _region
-        account = account if account is not None else _account
-        resource = resource if resource is not None else _resource
-
-    return f"arn:{partition}:{service}:{region}:{account}:{resource}"

--- a/aws_cfn_ses_domain/ses_email_identity.py
+++ b/aws_cfn_ses_domain/ses_email_identity.py
@@ -1,0 +1,73 @@
+# Amazon SES email identity provisioning
+
+import logging
+import os
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from .cfnresponse import FAILED, SUCCESS, send
+from .utils import format_arn
+
+
+logger = logging.getLogger()
+logger.setLevel(os.getenv("LOG_LEVEL", "WARNING"))
+
+
+DEFAULT_PROPERTIES = {
+    "EmailAddress": "",
+    "Region": os.getenv("AWS_REGION"),
+}
+
+
+def handle_email_identity_request(event, context):
+    logger.info("Received event %r", event)
+
+    properties = DEFAULT_PROPERTIES.copy()
+    properties.update(event["ResourceProperties"])
+    logger.info("Expanded properties to %r", properties)
+
+    # Clean and validate inputs
+    try:
+        properties["EmailAddress"] = properties["EmailAddress"].strip()
+    except (AttributeError, TypeError):
+        pass
+    email_address = properties["EmailAddress"]
+
+    if not email_address:
+        return send(event, context, FAILED,
+                    reason="The 'EmailAddress' property is required.",
+                    physical_resource_id="MISSING")
+
+    ses = boto3.client("ses", region_name=properties["Region"])
+
+    # Use an SES Identity ARN as the PhysicalResourceId - see:
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonses.html#amazonses-resources-for-iam-policies
+    email_arn = format_arn(
+        service="ses", region=properties["Region"],
+        resource_type="identity", resource_name=email_address,
+        defaults_from=event["StackId"])  # current stack's ARN has account and partition
+
+    try:
+        if event["RequestType"] == "Delete":
+            response = ses.delete_identity(Identity=email_address)
+            logger.info("SES:DeleteIdentity(Identity=%r) => %r", email_address, response)
+        else:
+            # Both Create and Update validate the new EmailAddress.
+            # (For Update, the change in physical_resource_id will cause CloudFormation
+            # to issue a Delete on the old EmailAddress after this request succeeds.)
+            response = ses.verify_email_identity(EmailAddress=email_address)
+            logger.info("SES:VerifyEmailIdentity(EmailAddress=%r) => %r", email_address, response)
+    except (BotoCoreError, ClientError) as error:
+        # for ClientError, might be helpful to look at error.response, too
+        logger.exception("Error updating SES: %s", error)
+        return send(event, context, FAILED,
+                    reason=str(error), physical_resource_id=email_arn)
+
+    outputs = {
+        "Arn": email_arn,
+        "EmailAddress": email_address,
+        "Region": properties["Region"],
+    }
+    return send(event, context, SUCCESS,
+                response_data=outputs, physical_resource_id=email_arn)

--- a/aws_cfn_ses_domain/utils.py
+++ b/aws_cfn_ses_domain/utils.py
@@ -1,0 +1,27 @@
+def format_arn(partition=None, service=None, region=None, account=None,
+               resource=None, resource_type=None, resource_name=None,
+               defaults_from=None):
+    """Return an ARN composed from the specified components.
+
+    Provide either resource or both resource_type and resource_name.
+
+    defaults_from can be an existing ARN, which will be used to fill in any
+    missing components.
+
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+    for the format.
+    """
+    if resource is None and resource_type is not None:
+        resource = f"{resource_type}/{resource_name}"
+    if defaults_from is not None:
+        try:
+            _arn, _partition, _service, _region, _account, _resource = defaults_from.split(":")
+        except (TypeError, ValueError):
+            raise ValueError(f"Invalid ARN in defaults_from={defaults_from!r}")
+        partition = partition if partition is not None else _partition
+        service = service if service is not None else _service
+        region = region if region is not None else _region
+        account = account if account is not None else _account
+        resource = resource if resource is not None else _resource
+
+    return f"arn:{partition}:{service}:{region}:{account}:{resource}"

--- a/example-usage.cf.yaml
+++ b/example-usage.cf.yaml
@@ -22,8 +22,8 @@ Parameters:
     Default: https://s3.amazonaws.com/YOUR_BUCKET_NAME/aws-cfn-ses-domain-VERSION.cf.yaml
 
 Conditions:
-  DeployDomainExample: !Equals [!Ref Domain, ""]
-  DeployEmailExample: !Equals [!Ref EmailAddress, ""]
+  DeployDomainExample: !Not [!Equals [!Ref Domain, ""]]
+  DeployEmailExample: !Not [!Equals [!Ref EmailAddress, ""]]
 
 Resources:
   # Use a nested stack to create the AWS Lambda Functions for the custom SES resources.

--- a/example-usage.cf.yaml
+++ b/example-usage.cf.yaml
@@ -9,25 +9,36 @@ Parameters:
     Type: String
     Description: >
       The domain name you want to provision for Amazon SES (e.g., "corp.example.com").
-  CfnSESDomainTemplateURL:
+    Default: ""
+  EmailAddress:
+    Type: String
+    Description: >
+      The email address you want to verify with Amazon SES (e.g., "sender@example.com").
+    Default: ""
+  CfnSESResourcesTemplateURL:
     Type: String
     Description: >
       The S3 url where you have uploaded your copy of aws-cfn-ses-domain.cf.yaml.
     Default: https://s3.amazonaws.com/YOUR_BUCKET_NAME/aws-cfn-ses-domain-VERSION.cf.yaml
 
+Conditions:
+  DeployDomainExample: !Equals [!Ref Domain, ""]
+  DeployEmailExample: !Equals [!Ref EmailAddress, ""]
+
 Resources:
-  # Use a nested stack to create the AWS Lambda Function for the Custom::SES_Domain type.
-  # This stack's "Arn" output is what you'll need for the custom resource's ServiceToken.
-  CfnSESDomain:
+  # Use a nested stack to create the AWS Lambda Functions for the custom SES resources.
+  # This stack's outputs include what you'll need for each custom resource's ServiceToken.
+  CfnSESResources:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Ref CfnSESDomainTemplateURL
+      TemplateURL: !Ref CfnSESResourcesTemplateURL
 
   # Use Custom::SES_Domain to provision a domain identity in SES
   MySESDomain:
     Type: Custom::SES_Domain
+    Condition: DeployDomainExample
     Properties:
-      ServiceToken: !GetAtt CfnSESDomain.Outputs.Arn
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomDomainIdentityArn
       # Domain is required; all others are optional
       Domain: !Ref Domain
       EnableReceive: true
@@ -35,12 +46,24 @@ Resources:
       MailFromSubdomain: "mail"
       TTL: "1800"
       CustomDMARC: '"v=DMARC1; p=none; pct=100; sp=none; aspf=r;"'
+      Region: !Ref AWS::Region
 
   # Add the necessary Route 53 DNS records for the SES domain identity.
   # (This assumes you already have a Route 53 hosted zone for Domain;
   # if not, add a Type: AWS::Route53::HostedZone resource to create it.)
   MyRoute53Records:
     Type: AWS::Route53::RecordSetGroup
+    Condition: DeployDomainExample
     Properties:
       HostedZoneName: !Sub "${Domain}."
       RecordSets: !GetAtt MySESDomain.Route53RecordSets
+
+  # Use Custom::SES_EmailIdentity to verify an email in SES
+  MySESEmail:
+    Type: Custom::SES_EmailIdentity
+    Condition: DeployEmailExample
+    Properties:
+      ServiceToken: !GetAtt CfnSESResources.Outputs.CustomEmailIdentityArn
+      # EmailAddress is required; all others are optional
+      EmailAddress: !Ref EmailAddress
+      Region: !Ref AWS::Region

--- a/index.py
+++ b/index.py
@@ -1,2 +1,2 @@
 # noinspection PyUnresolvedReferences
-from aws_cfn_ses_domain import lambda_handler
+from aws_cfn_ses_domain import handle_domain_identity_request, handle_email_identity_request

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,50 @@
+from unittest.case import TestCase
+from unittest.mock import patch, ANY as MOCK_ANY
+
+import boto3
+from botocore.stub import Stubber
+
+
+class HandlerTestCase(TestCase):
+    """Common test code for Amazon SES custom resource handlers.
+
+    Mocks boto3.client('ses') and cfnresponse.send, and
+    uses botocore.stub.Stubber to simulate/validate AWS responses.
+    """
+
+    maxDiff = None  # full diffs are helpful for Stubber assertions
+
+    # HandlerTestCase will patch boto3.client and cfnresponse.send within this module:
+    patch_base = 'aws_cfn_ses_domain.<handler_module>'  # concrete tests must override
+
+    def setUp(self):
+        self.mock_context = object()
+        self.mock_stack_id = "arn:aws:cloudformation:mock-region:111111111111:stack/example/deadbeef"
+
+        if self.patch_base == HandlerTestCase.patch_base:
+            raise NotImplementedError(f"{self.__class__.__name__} must override patch_base")
+
+        ses = boto3.client('ses')  # need a real client for Stubber
+        boto3_client_patcher = patch(f'{self.patch_base}.boto3.client', return_value=ses)
+        self.mock_boto3_client = boto3_client_patcher.start()
+        self.addCleanup(boto3_client_patcher.stop)
+
+        self.ses_stubber = Stubber(ses)
+        self.ses_stubber.activate()
+        self.addCleanup(self.ses_stubber.deactivate)
+
+        send_patcher = patch(f'{self.patch_base}.send')
+        self.mock_send = send_patcher.start()
+        self.addCleanup(send_patcher.stop)
+
+    def tearDown(self):
+        self.ses_stubber.assert_no_pending_responses()
+
+    def assertSentResponse(self, event=MOCK_ANY, context=None, status="SUCCESS", **kwargs):
+        """Asserts cfnresponse.send was called once, and returns response_data (if any)"""
+        if context is None:
+            context = self.mock_context
+        if status == "SUCCESS":
+            kwargs.setdefault("response_data", MOCK_ANY)
+        self.mock_send.assert_called_once_with(event, context, status, **kwargs)
+        return self.mock_send.call_args[1].get("response_data", None)

--- a/tests/test_ses_email_identity.py
+++ b/tests/test_ses_email_identity.py
@@ -1,0 +1,146 @@
+import os
+
+from .base import HandlerTestCase, MOCK_ANY
+
+os.environ["AWS_REGION"] = "mock-region"  # (before importing handler)
+from aws_cfn_ses_domain.ses_email_identity import handle_email_identity_request
+
+
+class TestEmailIdentityHandler(HandlerTestCase):
+
+    patch_base = 'aws_cfn_ses_domain.ses_email_identity'
+
+    def test_email_required(self):
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {},
+            "StackId": self.mock_stack_id}
+        handle_email_identity_request(event, self.mock_context)
+        self.assertSentResponse(
+            event, status="FAILED",
+            reason="The 'EmailAddress' property is required.",
+            physical_resource_id="MISSING")
+
+    def test_non_empty_email_required(self):
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {
+                "EmailAddress": " \t ",
+            },
+            "StackId": self.mock_stack_id}
+        handle_email_identity_request(event, self.mock_context)
+        self.assertSentResponse(
+            event, status="FAILED",
+            reason="The 'EmailAddress' property is required.",
+            physical_resource_id="MISSING")
+
+    def test_create_default(self):
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {
+                "EmailAddress": "sender@example.com",
+            },
+            "StackId": self.mock_stack_id}
+        self.ses_stubber.add_response(
+            'verify_email_identity',
+            {},
+            {'EmailAddress': "sender@example.com"})
+        handle_email_identity_request(event, self.mock_context)
+
+        # Should default to SES in current region (where stack is running):
+        self.mock_boto3_client.assert_called_once_with('ses', region_name="mock-region")
+
+        outputs = self.assertSentResponse(
+            event, physical_resource_id="arn:aws:ses:mock-region:111111111111:identity/sender@example.com")
+        self.assertEqual(outputs["EmailAddress"], "sender@example.com")
+        self.assertEqual(outputs["Region"], "mock-region")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:mock-region:111111111111:identity/sender@example.com")
+
+    def test_create_all_options(self):
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {
+                "EmailAddress": "  sender@example.com  ",
+                "Region": "us-test-2",
+            },
+            "StackId": self.mock_stack_id}
+        self.ses_stubber.add_response(
+            'verify_email_identity',
+            {},
+            {'EmailAddress': "sender@example.com"})
+        handle_email_identity_request(event, self.mock_context)
+
+        # Should override SES region when Region property provided:
+        self.mock_boto3_client.assert_called_once_with('ses', region_name="us-test-2")
+
+        outputs = self.assertSentResponse(
+            event, physical_resource_id="arn:aws:ses:us-test-2:111111111111:identity/sender@example.com")
+        self.assertEqual(outputs["Region"], "us-test-2")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:us-test-2:111111111111:identity/sender@example.com")
+
+    def test_update(self):
+        # Update is essentially the same as Create on the new address.
+        # CloudFormation will automatically Delete the old one once the resource id changes.
+        event = {
+            "RequestType": "Update",
+            "PhysicalResourceId": "arn:aws:ses:mock-region:111111111111:identity/sender@example.com",
+            "ResourceProperties": {
+                "EmailAddress": "other@example.org",
+            },
+            "StackId": self.mock_stack_id}
+        self.ses_stubber.add_response(
+            'verify_email_identity',
+            {},
+            {'EmailAddress': "other@example.org"})
+        handle_email_identity_request(event, self.mock_context)
+
+        outputs = self.assertSentResponse(
+            event, physical_resource_id="arn:aws:ses:mock-region:111111111111:identity/other@example.org")
+        self.assertEqual(outputs["Region"], "mock-region")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:mock-region:111111111111:identity/other@example.org")
+
+    def test_delete(self):
+        event = {
+            "RequestType": "Delete",
+            "PhysicalResourceId": "arn:aws:ses:mock-region:111111111111:identity/sender@example.com",
+            "ResourceProperties": {
+                "EmailAddress": "sender@example.com",
+            },
+            "StackId": self.mock_stack_id}
+        self.ses_stubber.add_response(
+            'delete_identity',
+            {},
+            {'Identity': "sender@example.com"})
+        handle_email_identity_request(event, self.mock_context)
+
+        outputs = self.assertSentResponse(
+            event, physical_resource_id="arn:aws:ses:mock-region:111111111111:identity/sender@example.com")
+        self.assertEqual(outputs["Region"], "mock-region")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:mock-region:111111111111:identity/sender@example.com")
+
+    def test_boto_error(self):
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {
+                "EmailAddress": "bad email",
+            },
+            "StackId": self.mock_stack_id}
+        self.ses_stubber.add_client_error(
+            'verify_email_identity',
+            "InvalidParameterValue",
+            "Invalid email address bad email.",
+            expected_params={'EmailAddress': "bad email"})
+        with self.assertLogs(level="ERROR") as cm:
+            handle_email_identity_request(event, self.mock_context)
+        self.assertSentResponse(
+            event, status="FAILED",
+            reason="An error occurred (InvalidParameterValue) when calling the"
+                   " VerifyEmailIdentity operation: Invalid email address bad email.",
+            physical_resource_id=MOCK_ANY)
+
+        # Check that the exception got logged
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn(
+            'ERROR:root:Error updating SES: An error occurred (InvalidParameterValue) when'
+            ' calling the VerifyEmailIdentity operation: Invalid email address bad email.',
+            cm.output[0])


### PR DESCRIPTION
Support for verifying/managing email addresses.

- [x] Rebase to master (once #3 merged)
- [x] Rework to support multiple resource types
- [x] Add resource handler for `Custom::SES_EmailIdentity`
- [x] Test email identity resource handler
- [x] Update cfn-lint spec
- [x] Update docs
- [x] Update/split example template
- [x] Test live examples
- ~Switch (docs/spec/example) from `Custom::SES_Domain` to `Custom::SES_DomainIdentity`?~ [seems like not-particularly-helpful verbosity]
- ~Rename package to `aws-cfn-ses-utils`?~ [maybe later, in a different PR]
