### PR TITLE
Update AWS Lambda runtime to python3.9

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           # This should match Lambda Runtime directive from aws-cfn-ses-domain.cf.yaml
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install dependencies
         run: make init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 *Unreleased changes*
 
-(none yet)
+### Fixes
+
+* Update AWS Lambda runtime to python3.9 (from deprecated python3.6).
 
 
 ## v0.3

--- a/aws-cfn-ses-domain.cf.yaml
+++ b/aws-cfn-ses-domain.cf.yaml
@@ -102,7 +102,7 @@ Resources:
       Description: CloudFormation custom SES domain provisioning
       Handler: index.handle_domain_identity_request
       Role: !GetAtt CustomDomainLambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Code:
         S3Bucket: !Ref LambdaCodeS3Bucket
         S3Key: !Ref LambdaCodeS3Key
@@ -113,7 +113,7 @@ Resources:
       Description: CloudFormation custom SES email identity provisioning
       Handler: index.handle_email_identity_request
       Role: !GetAtt CustomEmailLambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Code:
         S3Bucket: !Ref LambdaCodeS3Bucket
         S3Key: !Ref LambdaCodeS3Key

--- a/aws_cfn_ses_domain/__about__.py
+++ b/aws_cfn_ses_domain/__about__.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
     'Topic :: System :: Installation/Setup',
     'Topic :: System :: Systems Administration',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.9',
 ]
 
 KEYWORDS = [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords=" ".join(about["KEYWORDS"]),
 
     packages=packages,
-    python_requires='>=3.6.0',
+    python_requires='>=3.9.0',
     install_requires=[
         # Requirements listed here will be bundled into the Lambda Function zip file.
         # Note that the AWS Lambda execution environment has boto3 pre-installed.


### PR DESCRIPTION
Replaces deprecated python3.6 runtime.

Fixes #18